### PR TITLE
set werkzeug version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ requires-python = ">=3.7"
 version = "0.0.1"
 dependencies = [
     "Flask[async]==2.0.2",
+    "Werkzeug==2.2.2",
     "gunicorn==20.1.0",
     "google-api-python-client",
     "google-auth",


### PR DESCRIPTION
I hit this error recently 

> Traceback (most recent call last):
  File "/Users/ckachuli/automop/automop-env/bin/automop-webui", line 5, in <module>
    from automop.main import main
  File "/Users/ckachuli/automop/automop-env/lib/python3.11/site-packages/automop/main.py", line 3, in <module>
    import flask
  File "/Users/ckachuli/automop/automop-env/lib/python3.11/site-packages/flask/__init__.py", line 7, in <module>
    from .app import Flask as Flask
  File "/Users/ckachuli/automop/automop-env/lib/python3.11/site-packages/flask/app.py", line 28, in <module>
    from . import cli
  File "/Users/ckachuli/automop/automop-env/lib/python3.11/site-packages/flask/cli.py", line 18, in <module>
    from .helpers import get_debug_flag
  File "/Users/ckachuli/automop/automop-env/lib/python3.11/site-packages/flask/helpers.py", line 16, in <module>
    from werkzeug.urls import url_quote
ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/Users/ckachuli/automop/automop-env/lib/python3.11/site-packages/werkzeug/urls.py)

appears some dependency broke in flask, but can be fixed by fixing the version of werkzeug https://stackoverflow.com/questions/77213053/why-did-flask-start-failing-with-importerror-cannot-import-name-url-quote-fr